### PR TITLE
Fixes memory leaks on ViewPropertyAnimator

### DIFF
--- a/library/src/com/nineoldandroids/view/ViewPropertyAnimator.java
+++ b/library/src/com/nineoldandroids/view/ViewPropertyAnimator.java
@@ -69,6 +69,10 @@ public abstract class ViewPropertyAnimator {
         }
         return animator;
     }
+    
+    public static void unlink(View view) {
+    	ANIMATORS.remove(view);
+    }
 
 
     /**

--- a/library/src/com/nineoldandroids/view/ViewPropertyAnimator.java
+++ b/library/src/com/nineoldandroids/view/ViewPropertyAnimator.java
@@ -69,10 +69,6 @@ public abstract class ViewPropertyAnimator {
         }
         return animator;
     }
-    
-    public static void unlink(View view) {
-    	ANIMATORS.remove(view);
-    }
 
 
     /**

--- a/library/src/com/nineoldandroids/view/ViewPropertyAnimatorHC.java
+++ b/library/src/com/nineoldandroids/view/ViewPropertyAnimatorHC.java
@@ -16,6 +16,7 @@
 
 package com.nineoldandroids.view;
 
+import java.lang.ref.WeakReference;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Set;
@@ -25,11 +26,12 @@ import com.nineoldandroids.animation.Animator;
 import com.nineoldandroids.animation.ValueAnimator;
 
 class ViewPropertyAnimatorHC extends ViewPropertyAnimator {
+	
     /**
-     * The View whose properties are being animated by this class. This is set at
-     * construction time.
+     * A WeakReference holding the View whose properties are being animated by this class.
+     * This is set at construction time.
      */
-    private final View mView;
+    private final WeakReference<View> mView;
 
     /**
      * The duration of the underlying Animator object. By default, we don't set the duration
@@ -202,7 +204,7 @@ class ViewPropertyAnimatorHC extends ViewPropertyAnimator {
      * @param view The View associated with this ViewPropertyAnimator
      */
     ViewPropertyAnimatorHC(View view) {
-        mView = view;
+        mView = new WeakReference<View>(view);
     }
 
     /**
@@ -292,7 +294,10 @@ class ViewPropertyAnimatorHC extends ViewPropertyAnimator {
             }
         }
         mPendingAnimations.clear();
-        mView.removeCallbacks(mAnimationStarter);
+        View v = mView.get();
+        if (v != null) {
+        	v.removeCallbacks(mAnimationStarter);
+        }
     }
 
     @Override
@@ -511,8 +516,11 @@ class ViewPropertyAnimatorHC extends ViewPropertyAnimator {
 
         NameValuesHolder nameValuePair = new NameValuesHolder(constantName, startValue, byValue);
         mPendingAnimations.add(nameValuePair);
-        mView.removeCallbacks(mAnimationStarter);
-        mView.post(mAnimationStarter);
+        View v = mView.get();
+        if (v != null) {
+        	v.removeCallbacks(mAnimationStarter);
+        	v.post(mAnimationStarter);
+        }
     }
 
     /**
@@ -525,48 +533,51 @@ class ViewPropertyAnimatorHC extends ViewPropertyAnimator {
      */
     private void setValue(int propertyConstant, float value) {
         //final View.TransformationInfo info = mView.mTransformationInfo;
-        switch (propertyConstant) {
-            case TRANSLATION_X:
-                //info.mTranslationX = value;
-                mView.setTranslationX(value);
-                break;
-            case TRANSLATION_Y:
-                //info.mTranslationY = value;
-                mView.setTranslationY(value);
-                break;
-            case ROTATION:
-                //info.mRotation = value;
-                mView.setRotation(value);
-                break;
-            case ROTATION_X:
-                //info.mRotationX = value;
-                mView.setRotationX(value);
-                break;
-            case ROTATION_Y:
-                //info.mRotationY = value;
-                mView.setRotationY(value);
-                break;
-            case SCALE_X:
-                //info.mScaleX = value;
-                mView.setScaleX(value);
-                break;
-            case SCALE_Y:
-                //info.mScaleY = value;
-                mView.setScaleY(value);
-                break;
-            case X:
-                //info.mTranslationX = value - mView.mLeft;
-                mView.setX(value);
-                break;
-            case Y:
-                //info.mTranslationY = value - mView.mTop;
-                mView.setY(value);
-                break;
-            case ALPHA:
-                //info.mAlpha = value;
-                mView.setAlpha(value);
-                break;
-        }
+    	View v = mView.get();
+    	if (v != null) {
+	        switch (propertyConstant) {
+	            case TRANSLATION_X:
+	                //info.mTranslationX = value;
+	                v.setTranslationX(value);
+	                break;
+	            case TRANSLATION_Y:
+	                //info.mTranslationY = value;
+	                v.setTranslationY(value);
+	                break;
+	            case ROTATION:
+	                //info.mRotation = value;
+	                v.setRotation(value);
+	                break;
+	            case ROTATION_X:
+	                //info.mRotationX = value;
+	                v.setRotationX(value);
+	                break;
+	            case ROTATION_Y:
+	                //info.mRotationY = value;
+	                v.setRotationY(value);
+	                break;
+	            case SCALE_X:
+	                //info.mScaleX = value;
+	                v.setScaleX(value);
+	                break;
+	            case SCALE_Y:
+	                //info.mScaleY = value;
+	                v.setScaleY(value);
+	                break;
+	            case X:
+	                //info.mTranslationX = value - v.mLeft;
+	                v.setX(value);
+	                break;
+	            case Y:
+	                //info.mTranslationY = value - v.mTop;
+	                v.setY(value);
+	                break;
+	            case ALPHA:
+	                //info.mAlpha = value;
+	                v.setAlpha(value);
+	                break;
+	        }
+    	}
     }
 
     /**
@@ -577,38 +588,41 @@ class ViewPropertyAnimatorHC extends ViewPropertyAnimator {
      */
     private float getValue(int propertyConstant) {
         //final View.TransformationInfo info = mView.mTransformationInfo;
-        switch (propertyConstant) {
-            case TRANSLATION_X:
-                //return info.mTranslationX;
-                return mView.getTranslationX();
-            case TRANSLATION_Y:
-                //return info.mTranslationY;
-                return mView.getTranslationY();
-            case ROTATION:
-                //return info.mRotation;
-                return mView.getRotation();
-            case ROTATION_X:
-                //return info.mRotationX;
-                return mView.getRotationX();
-            case ROTATION_Y:
-                //return info.mRotationY;
-                return mView.getRotationY();
-            case SCALE_X:
-                //return info.mScaleX;
-                return mView.getScaleX();
-            case SCALE_Y:
-                //return info.mScaleY;
-                return mView.getScaleY();
-            case X:
-                //return mView.mLeft + info.mTranslationX;
-                return mView.getX();
-            case Y:
-                //return mView.mTop + info.mTranslationY;
-                return mView.getY();
-            case ALPHA:
-                //return info.mAlpha;
-                return mView.getAlpha();
-        }
+    	View v = mView.get();
+    	if (v != null) {
+	        switch (propertyConstant) {
+	            case TRANSLATION_X:
+	                //return info.mTranslationX;
+	                return v.getTranslationX();
+	            case TRANSLATION_Y:
+	                //return info.mTranslationY;
+	                return v.getTranslationY();
+	            case ROTATION:
+	                //return info.mRotation;
+	                return v.getRotation();
+	            case ROTATION_X:
+	                //return info.mRotationX;
+	                return v.getRotationX();
+	            case ROTATION_Y:
+	                //return info.mRotationY;
+	                return v.getRotationY();
+	            case SCALE_X:
+	                //return info.mScaleX;
+	                return v.getScaleX();
+	            case SCALE_Y:
+	                //return info.mScaleY;
+	                return v.getScaleY();
+	            case X:
+	                //return v.mLeft + info.mTranslationX;
+	                return v.getX();
+	            case Y:
+	                //return v.mTop + info.mTranslationY;
+	                return v.getY();
+	            case ALPHA:
+	                //return info.mAlpha;
+	                return v.getAlpha();
+	        }
+    	}
         return 0;
     }
 
@@ -631,7 +645,7 @@ class ViewPropertyAnimatorHC extends ViewPropertyAnimator {
         public void onAnimationCancel(Animator animation) {
             if (mListener != null) {
                 mListener.onAnimationCancel(animation);
-            }
+            }    
         }
 
         @Override
@@ -646,7 +660,13 @@ class ViewPropertyAnimatorHC extends ViewPropertyAnimator {
             if (mListener != null) {
                 mListener.onAnimationEnd(animation);
             }
-            mAnimatorMap.remove(animation);
+            mAnimatorMap.remove(animation);            
+            // If the map is empty, it means all animation are done or canceled, so the listener
+            // isn't needed anymore. Not nulling it would cause it to leak any objects used in
+            // its implementation
+            if (mAnimatorMap.isEmpty()) {
+                mListener = null;
+            }
         }
 
         /**
@@ -670,7 +690,10 @@ class ViewPropertyAnimatorHC extends ViewPropertyAnimator {
             PropertyBundle propertyBundle = mAnimatorMap.get(animation);
             int propertyMask = propertyBundle.mPropertyMask;
             if ((propertyMask & TRANSFORM_MASK) != 0) {
-                mView.invalidate(/*false*/);
+                View v = mView.get();
+                if (v != null) {
+                	v.invalidate(/*false*/);
+                }
             }
             ArrayList<NameValuesHolder> valueList = propertyBundle.mNameValuesHolder;
             if (valueList != null) {
@@ -691,7 +714,10 @@ class ViewPropertyAnimatorHC extends ViewPropertyAnimator {
             }*/
             // invalidate(false) in all cases except if alphaHandled gets set to true
             // via the call to setAlphaNoInvalidation(), above
-            mView.invalidate(/*alphaHandled*/);
+            View v = mView.get();
+            if (v != null) {
+            	v.invalidate(/*alphaHandled*/);
+            }
         }
     }
 }

--- a/library/src/com/nineoldandroids/view/ViewPropertyAnimatorICS.java
+++ b/library/src/com/nineoldandroids/view/ViewPropertyAnimatorICS.java
@@ -1,201 +1,298 @@
 package com.nineoldandroids.view;
 
+import java.lang.ref.WeakReference;
+
 import android.view.View;
 import android.view.animation.Interpolator;
 import com.nineoldandroids.animation.Animator.AnimatorListener;
 
 class ViewPropertyAnimatorICS extends ViewPropertyAnimator {
-    private final android.view.ViewPropertyAnimator mNative;
+	/**
+	 * A value to be returned when the WeakReference holding the native implementation
+	 * returns <code>null</code>
+	 */
+	private final static long RETURN_WHEN_NULL = -1L;
+
+	/**
+	 * A WeakReference holding the native implementation of ViewPropertyAnimator
+	 */
+    private final WeakReference<android.view.ViewPropertyAnimator> mNative;
 
     ViewPropertyAnimatorICS(View view) {
-        mNative = view.animate();
+        mNative = new WeakReference<android.view.ViewPropertyAnimator>(view.animate());
     }
 
     @Override
     public ViewPropertyAnimator setDuration(long duration) {
-        mNative.setDuration(duration);
+    	android.view.ViewPropertyAnimator n = mNative.get();
+    	if (n != null) {
+    		n.setDuration(duration);
+    	}
         return this;
     }
 
     @Override
     public long getDuration() {
-        return mNative.getDuration();
+    	android.view.ViewPropertyAnimator n = mNative.get();
+    	if (n != null) {
+    		return n.getDuration();
+    	}
+    	return RETURN_WHEN_NULL;
     }
 
     @Override
     public ViewPropertyAnimator setStartDelay(long startDelay) {
-        mNative.setStartDelay(startDelay);
+    	android.view.ViewPropertyAnimator n = mNative.get();
+    	if (n != null) {
+    		n.setStartDelay(startDelay);
+    	}
         return this;
     }
 
     @Override
     public long getStartDelay() {
-        return mNative.getStartDelay();
+    	android.view.ViewPropertyAnimator n = mNative.get();
+    	if (n != null) {
+    		return n.getStartDelay();
+    	}
+        return RETURN_WHEN_NULL;
     }
 
     @Override
     public ViewPropertyAnimator setInterpolator(Interpolator interpolator) {
-        mNative.setInterpolator(interpolator);
+    	android.view.ViewPropertyAnimator n = mNative.get();
+    	if (n != null) {
+    		n.setInterpolator(interpolator);
+    	}
         return this;
     }
 
     @Override
     public ViewPropertyAnimator setListener(final AnimatorListener listener) {
-        if (listener == null) {
-            mNative.setListener(null);
-        } else {
-            mNative.setListener(new android.animation.Animator.AnimatorListener() {
-                @Override
-                public void onAnimationStart(android.animation.Animator animation) {
-                    listener.onAnimationStart(null);
-                }
-
-                @Override
-                public void onAnimationRepeat(android.animation.Animator animation) {
-                    listener.onAnimationRepeat(null);
-                }
-
-                @Override
-                public void onAnimationEnd(android.animation.Animator animation) {
-                    listener.onAnimationEnd(null);
-                }
-
-                @Override
-                public void onAnimationCancel(android.animation.Animator animation) {
-                    listener.onAnimationCancel(null);
-                }
-            });
-        }
+    	android.view.ViewPropertyAnimator n = mNative.get();
+    	if (n != null) {
+		    if (listener == null) {        	
+		        n.setListener(null);
+		    } else {
+		        n.setListener(new android.animation.Animator.AnimatorListener() {
+		            @Override
+		            public void onAnimationStart(android.animation.Animator animation) {
+		                listener.onAnimationStart(null);
+		            }
+		
+		            @Override
+		            public void onAnimationRepeat(android.animation.Animator animation) {
+		                listener.onAnimationRepeat(null);
+		            }
+		
+		            @Override
+		            public void onAnimationEnd(android.animation.Animator animation) {
+		                listener.onAnimationEnd(null);
+		            }
+		
+		            @Override
+		            public void onAnimationCancel(android.animation.Animator animation) {
+		                listener.onAnimationCancel(null);
+		            }
+		        });
+		    }
+    	}
         return this;
     }
 
     @Override
     public void start() {
-        mNative.start();
+    	android.view.ViewPropertyAnimator n = mNative.get();
+    	if (n != null) {
+    		n.start();
+    	}
     }
 
     @Override
     public void cancel() {
-        mNative.cancel();
+    	android.view.ViewPropertyAnimator n = mNative.get();
+    	if (n != null) {
+    		n.cancel();
+    	}
     }
 
     @Override
     public ViewPropertyAnimator x(float value) {
-        mNative.x(value);
+    	android.view.ViewPropertyAnimator n = mNative.get();
+    	if (n != null) {
+    		n.x(value);
+    	}
         return this;
     }
 
     @Override
     public ViewPropertyAnimator xBy(float value) {
-        mNative.xBy(value);
+    	android.view.ViewPropertyAnimator n = mNative.get();
+    	if (n != null) {
+    		n.xBy(value);
+    	}
         return this;
     }
 
     @Override
     public ViewPropertyAnimator y(float value) {
-        mNative.y(value);
+    	android.view.ViewPropertyAnimator n = mNative.get();
+    	if (n != null) {
+    		n.y(value);
+    	}
         return this;
     }
 
     @Override
     public ViewPropertyAnimator yBy(float value) {
-        mNative.yBy(value);
+    	android.view.ViewPropertyAnimator n = mNative.get();
+    	if (n != null) {
+    		n.yBy(value);
+    	}
         return this;
     }
 
     @Override
     public ViewPropertyAnimator rotation(float value) {
-        mNative.rotation(value);
+    	android.view.ViewPropertyAnimator n = mNative.get();
+    	if (n != null) {
+    		n.rotation(value);
+    	}
         return this;
     }
 
     @Override
     public ViewPropertyAnimator rotationBy(float value) {
-        mNative.rotationBy(value);
+    	android.view.ViewPropertyAnimator n = mNative.get();
+    	if (n != null) {
+    		n.rotationBy(value);
+    	}
         return this;
     }
 
     @Override
     public ViewPropertyAnimator rotationX(float value) {
-        mNative.rotationX(value);
+    	android.view.ViewPropertyAnimator n = mNative.get();
+    	if (n != null) {
+    		n.rotationX(value);
+    	}
         return this;
     }
 
     @Override
     public ViewPropertyAnimator rotationXBy(float value) {
-        mNative.rotationXBy(value);
+    	android.view.ViewPropertyAnimator n = mNative.get();
+    	if (n != null) {
+    		n.rotationXBy(value);
+    	}    	
         return this;
     }
 
     @Override
     public ViewPropertyAnimator rotationY(float value) {
-        mNative.rotationY(value);
+    	android.view.ViewPropertyAnimator n = mNative.get();
+    	if (n != null) {
+    		n.rotationY(value);
+    	}
         return this;
     }
 
     @Override
     public ViewPropertyAnimator rotationYBy(float value) {
-        mNative.rotationYBy(value);
+    	android.view.ViewPropertyAnimator n = mNative.get();
+    	if (n != null) {
+    		n.rotationYBy(value);
+    	}
         return this;
     }
 
     @Override
     public ViewPropertyAnimator translationX(float value) {
-        mNative.translationX(value);
+    	android.view.ViewPropertyAnimator n = mNative.get();
+    	if (n != null) {
+    		n.translationX(value);
+    	}
         return this;
     }
 
     @Override
     public ViewPropertyAnimator translationXBy(float value) {
-        mNative.translationXBy(value);
+    	android.view.ViewPropertyAnimator n = mNative.get();
+    	if (n != null) {
+    		n.translationXBy(value);
+    	}
         return this;
     }
 
     @Override
     public ViewPropertyAnimator translationY(float value) {
-        mNative.translationY(value);
+    	android.view.ViewPropertyAnimator n = mNative.get();
+    	if (n != null) {
+    		n.translationY(value);
+    	}
         return this;
     }
 
     @Override
     public ViewPropertyAnimator translationYBy(float value) {
-        mNative.translationYBy(value);
+    	android.view.ViewPropertyAnimator n = mNative.get();
+    	if (n != null) {
+    		n.translationYBy(value);
+    	}
         return this;
     }
 
     @Override
     public ViewPropertyAnimator scaleX(float value) {
-        mNative.scaleX(value);
+    	android.view.ViewPropertyAnimator n = mNative.get();
+    	if (n != null) {
+    		n.scaleX(value);
+    	}
         return this;
     }
 
     @Override
     public ViewPropertyAnimator scaleXBy(float value) {
-        mNative.scaleXBy(value);
+    	android.view.ViewPropertyAnimator n = mNative.get();
+    	if (n != null) {
+    		n.scaleXBy(value);
+    	}
         return this;
     }
 
     @Override
     public ViewPropertyAnimator scaleY(float value) {
-        mNative.scaleY(value);
+    	android.view.ViewPropertyAnimator n = mNative.get();
+    	if (n != null) {
+    		n.scaleY(value);
+    	}
         return this;
     }
 
     @Override
     public ViewPropertyAnimator scaleYBy(float value) {
-        mNative.scaleYBy(value);
+    	android.view.ViewPropertyAnimator n = mNative.get();
+    	if (n != null) {
+    		n.scaleYBy(value);    		
+    	}
         return this;
     }
 
     @Override
     public ViewPropertyAnimator alpha(float value) {
-        mNative.alpha(value);
+    	android.view.ViewPropertyAnimator n = mNative.get();
+    	if (n != null) {
+    		n.alpha(value);
+    	}
         return this;
     }
 
     @Override
     public ViewPropertyAnimator alphaBy(float value) {
-        mNative.alphaBy(value);
+    	android.view.ViewPropertyAnimator n = mNative.get();
+    	if (n != null) {
+    		n.alphaBy(value);
+    	}
         return this;
     }
 }


### PR DESCRIPTION
Using a WeakReference only on the AnimatorProxy class wasn't enough to fix all MemoryLeaks. Hard references to the view on pre-HC and HC were also causing it to leak memory, as well as the pointer to the native instance on the ICS implementation.

The AnimatorListeners were also causing a memory leak, because if they referenced an object in their implementation, it would not get cleaned by the Garbage Collector. They are being nulled after the last animation finishes, so the view can be cleaned normally. Also, it doesn't make much sense for the way to class works to keep the listener after the animation has finished, as you would usually chain all methods in a single call and forget about it.
