### PR TITLE
Fix for AnimatorProxy cache mechanism.

### DIFF
--- a/library/src/com/nineoldandroids/view/animation/AnimatorProxy.java
+++ b/library/src/com/nineoldandroids/view/animation/AnimatorProxy.java
@@ -31,7 +31,8 @@ public final class AnimatorProxy extends Animation {
      */
     public static AnimatorProxy wrap(View view) {
         AnimatorProxy proxy = PROXIES.get(view);
-        if (proxy == null) {
+        // This checks if the proxy already exists and whether it still is the animation of the given view
+        if (proxy == null || proxy != view.getAnimation()) {
             proxy = new AnimatorProxy(view);
             PROXIES.put(view, proxy);
         }


### PR DESCRIPTION
Checks whether the AnimatorProxy still is the animation of the given view before reusing it.

Animations would stop working after a clearAnimation. That's a problem, because whenever a View is removed for its parent, its animation is cleared.
