### PR TITLE
Fixes animation between certain colors

### DIFF
--- a/library/src/com/nineoldandroids/animation/ArgbEvaluator.java
+++ b/library/src/com/nineoldandroids/animation/ArgbEvaluator.java
@@ -40,13 +40,13 @@ public class ArgbEvaluator implements TypeEvaluator {
      */
     public Object evaluate(float fraction, Object startValue, Object endValue) {
         int startInt = (Integer) startValue;
-        int startA = (startInt >> 24);
+        int startA = (startInt >> 24) & 0xff;
         int startR = (startInt >> 16) & 0xff;
         int startG = (startInt >> 8) & 0xff;
         int startB = startInt & 0xff;
 
         int endInt = (Integer) endValue;
-        int endA = (endInt >> 24);
+        int endA = (endInt >> 24) & 0xff;
         int endR = (endInt >> 16) & 0xff;
         int endG = (endInt >> 8) & 0xff;
         int endB = endInt & 0xff;


### PR DESCRIPTION
For some colors like Color.RED the ArgbEvaluation misread the alpha value as -1 instead of 255.
This causes certain animations to be invisible as the animator then tries to animate between 0 and -1
instead of 0 and 255.
