### PR TITLE
correctly clone keyframe with no value

### DIFF
--- a/library/src/com/nineoldandroids/animation/Keyframe.java
+++ b/library/src/com/nineoldandroids/animation/Keyframe.java
@@ -308,7 +308,13 @@ public abstract class Keyframe implements Cloneable {
 
         @Override
         public IntKeyframe clone() {
-            IntKeyframe kfClone = new IntKeyframe(getFraction(), mValue);
+            IntKeyframe kfClone;
+            if (mHasValue) {
+        		kfClone = new IntKeyframe(getFraction(), mValue);
+        	}
+        	else {
+        		kfClone = new IntKeyframe(getFraction());
+        	}
             kfClone.setInterpolator(getInterpolator());
             return kfClone;
         }
@@ -352,7 +358,13 @@ public abstract class Keyframe implements Cloneable {
 
         @Override
         public FloatKeyframe clone() {
-            FloatKeyframe kfClone = new FloatKeyframe(getFraction(), mValue);
+        	FloatKeyframe kfClone;
+        	if (mHasValue) {
+        		kfClone = new FloatKeyframe(getFraction(), mValue);
+        	}
+        	else {
+        		kfClone = new FloatKeyframe(getFraction());
+        	}
             kfClone.setInterpolator(getInterpolator());
             return kfClone;
         }


### PR DESCRIPTION
When cloning a set keyframe with no value set were cloned as "with" value.
