### PR TITLE
Add empty <application /> element to avoid a Gradle manifest merging error.

### DIFF
--- a/library/AndroidManifest.xml
+++ b/library/AndroidManifest.xml
@@ -7,5 +7,7 @@
 	android:versionName="2.4.0">
 	
     <uses-sdk android:minSdkVersion="1" />
+    
+    <application />
 
 </manifest>


### PR DESCRIPTION
Per Android Team (http://stackoverflow.com/a/17757200/937715), library manifests should include an empty `<application />` element.  Otherwise, the application cannot use a targetSdkVersion number that is different than the library when using Gradle/Android Studio.  If the app uses a different targetSdkVersion, you get a compile error `Manifest merging failed. - Main manifest has <uses-sdk android:targetSdkVersion='8'> but library uses targetSdkVersion='19'`.
