### PR TITLE
fix view display issues when alpha is negative

### DIFF
--- a/library/src/com/nineoldandroids/view/animation/AnimatorProxy.java
+++ b/library/src/com/nineoldandroids/view/animation/AnimatorProxy.java
@@ -315,7 +315,7 @@ public final class AnimatorProxy extends Animation {
     protected void applyTransformation(float interpolatedTime, Transformation t) {
         View view = mView.get();
         if (view != null) {
-            t.setAlpha(mAlpha);
+            t.setAlpha(Math.max(0, mAlpha));
             transformMatrix(t.getMatrix(), view);
         }
     }


### PR DESCRIPTION
Hi Jake, In the platform which api level is lower than 11, the alpha can't be set as negative, otherwise the view will be opaque.
e.g. a alpha animation from 1...0 with OvershotInterpolator.
