### PR TITLE
Samsung Compatibility-Fix 2.3.6 - 2.3.7

### DIFF
--- a/library/src/com/nineoldandroids/animation/AnimatorInflater.java
+++ b/library/src/com/nineoldandroids/animation/AnimatorInflater.java
@@ -256,10 +256,9 @@ public class AnimatorInflater {
                 if (fromType == TypedValue.TYPE_DIMENSION) {
                     valueFrom = a.getDimension(valueFromIndex, 0f);
                 } else {
-                	TypedValue value = new TypedValue();
-					a.getValue(valueFromIndex, value);
-					valueFrom = value.type == TypedValue.TYPE_FLOAT ? value.data
-							: -1;
+                    TypedValue value = new TypedValue();
+                    a.getValue(valueFromIndex, value);
+                    valueFrom = value.type == TypedValue.TYPE_FLOAT ? value.data : -1;
                 }
                 if (hasTo) {
                     if (toType == TypedValue.TYPE_DIMENSION) {

--- a/library/src/com/nineoldandroids/animation/AnimatorInflater.java
+++ b/library/src/com/nineoldandroids/animation/AnimatorInflater.java
@@ -256,7 +256,10 @@ public class AnimatorInflater {
                 if (fromType == TypedValue.TYPE_DIMENSION) {
                     valueFrom = a.getDimension(valueFromIndex, 0f);
                 } else {
-                    valueFrom = a.getFloat(valueFromIndex, 0f);
+                	TypedValue value = new TypedValue();
+					a.getValue(valueFromIndex, value);
+					valueFrom = value.type == TypedValue.TYPE_FLOAT ? value.data
+							: -1;
                 }
                 if (hasTo) {
                     if (toType == TypedValue.TYPE_DIMENSION) {


### PR DESCRIPTION
This fix resolves issues with older Samsung Android phones, when inflating objectanimator xml files.
Its a rather old fix I implemented for older Samsung phones.
